### PR TITLE
[will re-request] Sun phase calculations now return same timezone as original

### DIFF
--- a/src/main/java/com/florianmski/suncalc/SunCalc.java
+++ b/src/main/java/com/florianmski/suncalc/SunCalc.java
@@ -53,6 +53,14 @@ public class SunCalc
         return (1 + Math.cos(inc)) / 2;
     }
 
+    /**
+     * Calculates phases of the sun for a single day
+     *
+     * @param date the day to calculate sun positions for
+     * @param lat measured from North, in degrees
+     * @param lng measured from East, in degrees
+     * @return phases by name, with their start/end times and angles
+     */
     public static List<SunPhase> getPhases(Calendar date, double lat, double lng)
     {
         double lw  = Constants.RAD * -lng;

--- a/src/main/java/com/florianmski/suncalc/SunCalc.java
+++ b/src/main/java/com/florianmski/suncalc/SunCalc.java
@@ -6,6 +6,7 @@ import com.florianmski.suncalc.utils.*;
 
 import java.util.Calendar;
 import java.util.List;
+import java.util.TimeZone;
 
 public class SunCalc
 {
@@ -80,10 +81,15 @@ public class SunCalc
 
         List<SunPhase> results = SunPhase.all();
 
+        TimeZone originalTimeZone = date.getTimeZone();
         for(SunPhase sunPhase : results)
         {
-            sunPhase.setStartDate(getPhaseDate(sunPhase.getStartAngle(), sunPhase.isStartRise(), jnoon, phi, dec, lw, n, M, L));
-            sunPhase.setEndDate(getPhaseDate(sunPhase.getEndAngle(), sunPhase.isEndRise(), jnoon, phi, dec, lw, n, M, L));
+            Calendar startDate = getPhaseDate(sunPhase.getStartAngle(), sunPhase.isStartRise(), jnoon, phi, dec, lw, n, M, L);
+            startDate.setTimeZone(originalTimeZone);
+            sunPhase.setStartDate(startDate);
+            Calendar endDate = getPhaseDate(sunPhase.getEndAngle(), sunPhase.isEndRise(), jnoon, phi, dec, lw, n, M, L);
+            endDate.setTimeZone(originalTimeZone);
+            sunPhase.setEndDate(endDate);
         }
 
         // not pretty, this is to have correct dates

--- a/src/main/java/com/florianmski/suncalc/models/SunPhase.java
+++ b/src/main/java/com/florianmski/suncalc/models/SunPhase.java
@@ -9,19 +9,19 @@ public class SunPhase
 {
     public enum Name
     {
-        NIGHT_MORNING("Night"),
-        TWILIGHT_ASTRONOMICAL_MORNING("Twilight Astronomical"),
-        TWILIGHT_NAUTICAL_MORNING("Twilight Nautical"),
-        TWILIGHT_CIVIL_MORNING("Twilight Civil"),
+        NIGHT_MORNING("Night Morning"),
+        TWILIGHT_ASTRONOMICAL_MORNING("Twilight Astronomical Morning"),
+        TWILIGHT_NAUTICAL_MORNING("Twilight Nautical Morning"),
+        TWILIGHT_CIVIL_MORNING("Twilight Civil Morning"),
         SUNRISE("Sunrise"),
-        GOLDEN_HOUR_MORNING("Golden Hour"),
+        GOLDEN_HOUR_MORNING("Golden Hour Morning"),
         DAYLIGHT("Daylight"),
-        GOLDEN_HOUR_EVENING("Golden Hour"),
+        GOLDEN_HOUR_EVENING("Golden Hour Evening"),
         SUNSET("Sunset"),
-        TWILIGHT_CIVIL_EVENING("Twilight Civil"),
-        TWILIGHT_NAUTICAL_EVENING("Twilight Nautical"),
-        TWILIGHT_ASTRONOMICAL_EVENING("Twilight Astronomical"),
-        NIGHT_EVENING("Night");
+        TWILIGHT_CIVIL_EVENING("Twilight Civil Evening"),
+        TWILIGHT_NAUTICAL_EVENING("Twilight Nautical Evening"),
+        TWILIGHT_ASTRONOMICAL_EVENING("Twilight Astronomical Evening"),
+        NIGHT_EVENING("Night Evening");
 
         private final String value;
         private Name(String value)
@@ -85,7 +85,7 @@ public class SunPhase
             case TWILIGHT_NAUTICAL_EVENING:
                 return new SunPhase(name, SunAngles.TWILIGHT_NAUTICAL_EVENING_START, false, SunAngles.TWILIGHT_NAUTICAL_EVENING_END, false);
             case TWILIGHT_CIVIL_EVENING:
-                return new SunPhase(name, SunAngles.TWILIGHT_CIVIC_EVENING_START, false, SunAngles.TWILIGHT_CIVIC_EVENING_END, false);
+                return new SunPhase(name, SunAngles.TWILIGHT_CIVIL_EVENING_START, false, SunAngles.TWILIGHT_CIVIL_EVENING_END, false);
             case NIGHT_EVENING:
                 return new SunPhase(name, SunAngles.NIGHT_START, false, SunAngles.NIGHT_END, true);
             case NIGHT_MORNING:
@@ -152,5 +152,18 @@ public class SunPhase
     public void setEndDate(Calendar endDate)
     {
         this.endDate = endDate;
+    }
+
+    @Override
+    public String toString() {
+        return "SunPhase{" +
+                "name=" + name +
+                ", startAngle=" + startAngle +
+                ", endAngle=" + endAngle +
+                ", startRise=" + startRise +
+                ", endRise=" + endRise +
+                ", startDate=" + startDate +
+                ", endDate=" + endDate +
+                '}';
     }
 }

--- a/src/main/java/com/florianmski/suncalc/utils/Constants.java
+++ b/src/main/java/com/florianmski/suncalc/utils/Constants.java
@@ -2,35 +2,74 @@ package com.florianmski.suncalc.utils;
 
 public class Constants
 {
+    /** units: radians/degrees */
     public final static double RAD = Math.PI / 180.0;
-    public final static double E = RAD * 23.4397; // obliquity of the Earth
 
+    /** obliquity of the Earth */
+    public final static double E = RAD * 23.4397;
+
+    /**
+     * <p>
+     *     Solar elevation angles in degrees, i.e. the angle of the sun from the horizon.
+     *     Defined as 90 deg - solar zenith angle.
+     * </p>
+     * <p>
+     *     See <a href="https://en.wikipedia.org/wiki/Solar_zenith_angle">
+     *     https://en.wikipedia.org/wiki/Solar_zenith_angle</a> and
+     *     <a href="https://en.wikipedia.org/wiki/Twilight">https://en.wikipedia.org/wiki/Twilight</a>
+     *     for more info.
+     * </p>
+     */
     public class SunAngles
     {
+        /** sunrise (top edge of the sun appears on the horizon) */
         public final static double SUNRISE_START                        = -0.833;
-        public final static double GOLDEN_HOUR_MORNING_START            = -0.3;
+        /** morning golden hour starts (soft light, best time for photography) */
+         public final static double GOLDEN_HOUR_MORNING_START            = -0.3;
+        /** daylight starts */
         public final static double DAYLIGHT_START                       = 6.0;
+        /** evening golden hour starts */
         public final static double GOLDEN_HOUR_EVENING_START            = DAYLIGHT_START;
+        /** sunset starts (bottom edge of the sun touches the horizon) */
         public final static double SUNSET_START                         = GOLDEN_HOUR_MORNING_START;
-        public final static double TWILIGHT_CIVIC_EVENING_START         = SUNRISE_START;
+        /** evening civil twilight starts (sun disappears below the horizon) */
+        public final static double TWILIGHT_CIVIL_EVENING_START = SUNRISE_START;
+        /** evening nautical twilight starts (many brighter stars start appearing, horizon faintly visible) */
         public final static double TWILIGHT_NAUTICAL_EVENING_START      = -6.0;
+        /** evening astronomical twilight starts (fainter stars start appearing) */
         public final static double TWILIGHT_ASTRONOMICAL_EVENING_START  = -12.0;
+        /** night starts (dark enough for astronomical observations) */
         public final static double NIGHT_START                          = -18.0;
+        /** astronomical dawn (fainter stars start disappearing) */
         public final static double TWILIGHT_ASTRONOMICAL_MORNING_START  = NIGHT_START;
+        /** nautical dawn (brighter stars start disappearing) */
         public final static double TWILIGHT_NAUTICAL_MORNING_START      = TWILIGHT_ASTRONOMICAL_EVENING_START;
+        /** dawn (atmosphere begins to scatter light) */
         public final static double TWILIGHT_CIVIL_MORNING_START         = TWILIGHT_NAUTICAL_EVENING_START;
 
+        /** sunrise ends (bottom edge of the sun touches the horizon) */
         public final static double SUNRISE_END                          = GOLDEN_HOUR_MORNING_START;
+        /** morning golden hour (soft light, best time for photography) ends */
         public final static double GOLDEN_HOUR_MORNING_END              = DAYLIGHT_START;
+        /** daylight ends, evening golden hour starts */
         public final static double DAYLIGHT_END                         = GOLDEN_HOUR_EVENING_START;
+        /** sunset starts (bottom edge of the sun touches the horizon) */
         public final static double GOLDEN_HOUR_EVENING_END              = SUNSET_START;
-        public final static double SUNSET_END                           = TWILIGHT_CIVIC_EVENING_START;
-        public final static double TWILIGHT_CIVIC_EVENING_END           = TWILIGHT_NAUTICAL_EVENING_START;
+        /** sunset ends (sun disappears below the horizon) */
+        public final static double SUNSET_END                           = TWILIGHT_CIVIL_EVENING_START;
+        /** dusk (many brighter stars start appearing, horizon faintly visible) */
+        public final static double TWILIGHT_CIVIL_EVENING_END = TWILIGHT_NAUTICAL_EVENING_START;
+        /** nautical dusk (fainter stars start appearing) */
         public final static double TWILIGHT_NAUTICAL_EVENING_END        = TWILIGHT_ASTRONOMICAL_EVENING_START;
+        /** night starts, astronomical dusk (dark enough for astronomical observations) */
         public final static double TWILIGHT_ASTRONOMICAL_EVENING_END    = NIGHT_START;
+        /** night ends (fainter stars start disappearing) */
         public final static double NIGHT_END                            = TWILIGHT_ASTRONOMICAL_MORNING_START;
+        /** morning astronomical twilight ends (brighter stars start disappearing) */
         public final static double TWILIGHT_ASTRONOMICAL_MORNING_END    = TWILIGHT_NAUTICAL_MORNING_START;
+        /** morning nautical twilight ends (atmosphere begins to scatter light) */
         public final static double TWILIGHT_NAUTICAL_MORNING_END        = TWILIGHT_CIVIL_MORNING_START;
+        /** morning civil twilight ends (top edge of the sun appears on the horizon) */
         public final static double TWILIGHT_CIVIL_MORNING_END           = SUNRISE_START;
     }
 }

--- a/src/test/groovy/com/florianmski/suncalc/SunCalcSpec.groovy
+++ b/src/test/groovy/com/florianmski/suncalc/SunCalcSpec.groovy
@@ -177,5 +177,30 @@ class SunCalcSpec extends spock.lang.Specification {
         return Math.abs(val1 - val2) < (margin)
     }
 
+    def "calculations should return same timezone as original: #timeZone"() {
+
+        given:
+        // Mumbai, India
+        double lat = 19.08
+        double lng = 72.88
+        TimeZone originalTimeZone = TimeZone.getTimeZone(timeZone)
+        Calendar d = Calendar.getInstance(originalTimeZone)
+        d.setTime(new Date())
+
+        when:
+        List<SunPhase> phases = SunCalc.getPhases(d, lat, lng)
+
+        then:
+        phases.forEach {
+            assert it.startDate.timeZone == originalTimeZone
+            assert it.endDate.timeZone == originalTimeZone
+        }
+
+        where:
+        // have at least two time zones for the test, in case one of them is the tester's native one
+        timeZone   | _
+        'GMT+5:50' | _
+        'GMT-8:00' | _
+    }
 
 }


### PR DESCRIPTION
Code fix for https://github.com/florianmski/SunCalc-Java/issues/6

Kind of gross because of the Calendar API, but this at least is a start until we perhaps switch to Java 8-esque LocalDate and LocalTime APIs

**To prevent confusion in merge/revision history** (3 files changed where really there are only 2), the earlier pull request https://github.com/florianmski/SunCalc-Java/pull/5 should be pulled up first