### PR TITLE
Sun phases now return times in same timezone as original

### DIFF
--- a/src/main/java/com/florianmski/suncalc/SunCalc.java
+++ b/src/main/java/com/florianmski/suncalc/SunCalc.java
@@ -6,6 +6,7 @@ import com.florianmski.suncalc.utils.*;
 
 import java.util.Calendar;
 import java.util.List;
+import java.util.TimeZone;
 
 /**
  * Calculations for the sun and moon relative to earth
@@ -109,10 +110,16 @@ public class SunCalc
 
         List<SunPhase> results = SunPhase.all();
 
+        TimeZone originalTimeZone = date.getTimeZone();
         for(SunPhase sunPhase : results)
         {
-            sunPhase.setStartDate(getPhaseDate(sunPhase.getStartAngle(), sunPhase.isStartRise(), jnoon, phi, dec, lw, n, M, L));
-            sunPhase.setEndDate(getPhaseDate(sunPhase.getEndAngle(), sunPhase.isEndRise(), jnoon, phi, dec, lw, n, M, L));
+            // not pretty, this is to have correct timezones
+            Calendar startDate = getPhaseDate(sunPhase.getStartAngle(), sunPhase.isStartRise(), jnoon, phi, dec, lw, n, M, L);
+            startDate.setTimeZone(originalTimeZone);
+            sunPhase.setStartDate(startDate);
+            Calendar endDate = getPhaseDate(sunPhase.getEndAngle(), sunPhase.isEndRise(), jnoon, phi, dec, lw, n, M, L);
+            endDate.setTimeZone(originalTimeZone);
+            sunPhase.setEndDate(endDate);
         }
 
         // not pretty, this is to have correct dates

--- a/src/test/groovy/com/florianmski/suncalc/SunCalcSpec.groovy
+++ b/src/test/groovy/com/florianmski/suncalc/SunCalcSpec.groovy
@@ -154,6 +154,32 @@ class SunCalcSpec extends spock.lang.Specification {
 
     }
 
+    def "calculations should return same timezone as original: #timeZone"() {
+
+        given:
+        // Mumbai, India
+        double lat = 19.08
+        double lng = 72.88
+        TimeZone originalTimeZone = TimeZone.getTimeZone(timeZone)
+        Calendar d = Calendar.getInstance(originalTimeZone)
+        d.setTime(new Date())
+
+        when:
+        List<SunPhase> phases = SunCalc.getPhases(d, lat, lng)
+
+        then:
+        phases.forEach {
+            assert it.startDate.timeZone == originalTimeZone
+            assert it.endDate.timeZone == originalTimeZone
+        }
+
+        where:
+        // have at least two time zones for the test, in case one of them is the tester's native one
+        timeZone   | _
+        'GMT+5:50' | _
+        'GMT-8:00' | _
+    }
+
     // ----------------------- MOON CALCULATION TESTS -------------------------------
 
     @Shared


### PR DESCRIPTION
Code fix for #6

Actual pull request, since the previous one (https://github.com/florianmski/SunCalc-Java/pull/7) had too many things in the branch.

This fix is a little verbose because of the Calendar API but is at least is a start until we perhaps switch to Java 8-esque LocalDate and LocalTime APIs